### PR TITLE
fix!: Prevent Object.prototype builtins from leaking into interpreter environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `interpret()` now only uses identifiers, numeric functions, and reference
+  functions that are *directly-owned* properties of fields in the `environment`
+  object. For example, the following no longer works:
+
+  ```js
+  class Parent {
+    myfunc(a, b) { /* ... */ }
+  }
+  class Child extends Parent {}
+
+  // Previously, interpret() used Child.myfunc(), inherited from Parent.
+  // With this change, it now throws a "Unknown function" D2FInterpreterError.
+  interpret("myfunc(10, 20)", { functions: new Child() });
+  ```
+
+  This prevents inherited properties (such as those in `Object.prototype`) from
+  accidentally leaking into the environment.
 
 ## [0.1.1] - 2020-07-21
 ### Fixed

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -186,7 +186,9 @@ function interpretBinaryOp(expression, environment) {
 function interpretFunctionCall(expression, environment) {
   const { functionName, arg1, arg2 } = expression;
   const { functions = {} } = environment;
-  const func = functions[functionName];
+  const func = Object.prototype.hasOwnProperty.call(functions, functionName)
+    ? functions[functionName]
+    : undefined;
 
   if (func == undefined) {
     throw new D2FInterpreterError(`Unknown function: ${functionName}`);
@@ -212,7 +214,12 @@ function interpretFunctionCall(expression, environment) {
  */
 function interpretIdentifier(expression, environment) {
   const { identifiers = {} } = environment;
-  const identifier = identifiers[expression.name];
+  const identifier = Object.prototype.hasOwnProperty.call(
+    identifiers,
+    expression.name
+  )
+    ? identifiers[expression.name]
+    : undefined;
 
   if (identifier == undefined) {
     throw new D2FInterpreterError(`Unknown identifier: ${expression.name}`);
@@ -240,7 +247,12 @@ function interpretRefFunctionCall(expression, environment) {
 
   if (code2 == null) {
     const { referenceFunctions = {} } = environment;
-    const func = referenceFunctions[functionName];
+    const func = Object.prototype.hasOwnProperty.call(
+      referenceFunctions,
+      functionName
+    )
+      ? referenceFunctions[functionName]
+      : undefined;
 
     if (func == undefined) {
       throw new D2FInterpreterError(
@@ -266,7 +278,12 @@ function interpretRefFunctionCall(expression, environment) {
     }
   } else {
     const { referenceFunctions2Q = {} } = environment;
-    const func = referenceFunctions2Q[functionName];
+    const func = Object.prototype.hasOwnProperty.call(
+      referenceFunctions2Q,
+      functionName
+    )
+      ? referenceFunctions2Q[functionName]
+      : undefined;
 
     if (func == undefined) {
       throw new D2FInterpreterError(

--- a/test/interpreter.test.js
+++ b/test/interpreter.test.js
@@ -1,6 +1,7 @@
 import { strict as assert } from "assert";
 import sinon from "sinon";
 
+import { D2FInterpreterError } from "../src/errors.js";
 import interpret from "../src/interpreter.js";
 
 /**
@@ -203,6 +204,76 @@ describe("interpret()", () => {
     itInterpretsTo("-2147483648", {}, -2147483648);
     itInterpretsTo("2147483648 * -1", {}, -2147483648);
     itInterpretsTo("-1 * 2147483648", {}, -2147483648);
+  });
+
+  it("should not treat Object.prototype builtins as identifiers", () => {
+    assert.throws(
+      () => interpret("hasOwnProperty"),
+      new D2FInterpreterError(`Unknown identifier: hasOwnProperty`)
+    );
+    assert.throws(
+      () => interpret("toString"),
+      new D2FInterpreterError(`Unknown identifier: toString`)
+    );
+    assert.throws(
+      () => interpret("valueOf"),
+      new D2FInterpreterError(`Unknown identifier: valueOf`)
+    );
+  });
+
+  it("should not treat Object.prototype builtins as numeric functions", () => {
+    assert.throws(
+      () => interpret("hasOwnProperty(1, 2)"),
+      new D2FInterpreterError(`Unknown function: hasOwnProperty`)
+    );
+    assert.throws(
+      () => interpret("toString(1, 2)"),
+      new D2FInterpreterError(`Unknown function: toString`)
+    );
+    assert.throws(
+      () => interpret("valueOf(1, 2)"),
+      new D2FInterpreterError(`Unknown function: valueOf`)
+    );
+  });
+
+  it("should not treat Object.prototype builtins as reference functions", () => {
+    assert.throws(
+      () => interpret("hasOwnProperty('foo'.qualifier)"),
+      new D2FInterpreterError(
+        `Unknown single-qualifier reference function: hasOwnProperty`
+      )
+    );
+    assert.throws(
+      () => interpret("toString('foo'.qualifier)"),
+      new D2FInterpreterError(
+        `Unknown single-qualifier reference function: toString`
+      )
+    );
+    assert.throws(
+      () => interpret("valueOf('foo'.qualifier)"),
+      new D2FInterpreterError(
+        `Unknown single-qualifier reference function: valueOf`
+      )
+    );
+
+    assert.throws(
+      () => interpret("hasOwnProperty('foo'.qual1.qual2)"),
+      new D2FInterpreterError(
+        `Unknown double-qualifier reference function: hasOwnProperty`
+      )
+    );
+    assert.throws(
+      () => interpret("toString('foo'.qual1.qual2)"),
+      new D2FInterpreterError(
+        `Unknown double-qualifier reference function: toString`
+      )
+    );
+    assert.throws(
+      () => interpret("valueOf('foo'.qual1.qual2)"),
+      new D2FInterpreterError(
+        `Unknown double-qualifier reference function: valueOf`
+      )
+    );
   });
 });
 


### PR DESCRIPTION
`interpret()` now only reads identifiers, numeric functions, and reference functions that are *directly-owned* properties of fields in the `InterpreterEnvironment` object. This prevents properties inherited through the prototype chain, such as those in `Object.prototype`, from leaking into the D2F execution environment.

For example, the following no longer works:

```js
class Parent {
  myfunc(a, b) { /* ... */ }
}
class Child extends Parent {}

// Previously, interpret() used Child.myfunc(), inherited from Parent.
// With this change, it now throws a "Unknown function" D2FInterpreterError.
interpret("myfunc(10, 20)", { functions: new Child() });
```