### PR TITLE
CachedInterpreter correctly handles builtin property names in Object.prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This prevents inherited properties (such as those in `Object.prototype`) from
   accidentally leaking into the environment.
+- Fixed a bug that caused `CachedInterpreter.interpret()` to behave incorrectly
+  when property names in `Object.prototype` were given as formulae.
 
 ## [0.1.1] - 2020-07-21
 ### Fixed

--- a/src/cached-interpreter.js
+++ b/src/cached-interpreter.js
@@ -17,10 +17,10 @@ import parse from "./parser.js";
 export class CachedInterpreter {
   constructor() {
     /**
-     * @type {{ [text: string]: AstExpression }}
+     * @type {Map<string, AstExpression>}
      * @private
      */
-    this.astCache_ = {};
+    this.astCache_ = new Map();
   }
 
   /**
@@ -39,9 +39,9 @@ export class CachedInterpreter {
    *    error occurs while interpreting the result
    */
   interpret(text, environment = {}) {
-    let expression = this.astCache_[text];
+    let expression = this.astCache_.get(text);
     if (!expression) {
-      expression = this.astCache_[text] = parse(text);
+      this.astCache_.set(text, (expression = parse(text)));
     }
     return interpretExpression(expression, environment);
   }

--- a/test/cached-interpreter.test.js
+++ b/test/cached-interpreter.test.js
@@ -9,19 +9,19 @@ describe("CachedInterpreter", () => {
     // @ts-expect-error Accessing private property for test
     const astCache = interpreter.astCache_;
 
-    assert.strictEqual(0, Object.keys(astCache).length);
+    assert.strictEqual(0, astCache.size);
 
     const formula1 = "2 + 5";
     const formula2 = "((12 + 34) / -5 < 100) ? 67 : 89";
 
     interpreter.interpret(formula1);
-    assert.strictEqual(1, Object.keys(astCache).length);
-    assert.ok(Object.prototype.hasOwnProperty.call(astCache, formula1));
-    const ast1Before = astCache[formula1];
+    assert.strictEqual(1, astCache.size);
+    assert.ok(astCache.has(formula1));
+    const ast1Before = astCache.get(formula1);
 
     interpreter.interpret(formula1);
-    assert.strictEqual(1, Object.keys(astCache).length);
-    const ast1After = astCache[formula1];
+    assert.strictEqual(1, astCache.size);
+    const ast1After = astCache.get(formula1);
 
     assert.strictEqual(
       ast1Before,
@@ -30,13 +30,13 @@ describe("CachedInterpreter", () => {
     );
 
     interpreter.interpret(formula2);
-    assert.strictEqual(2, Object.keys(astCache).length);
-    assert.ok(Object.prototype.hasOwnProperty.call(astCache, formula2));
-    const ast2Before = astCache[formula2];
+    assert.strictEqual(2, astCache.size);
+    assert.ok(astCache.has(formula2));
+    const ast2Before = astCache.get(formula2);
 
     interpreter.interpret(formula2);
-    assert.strictEqual(2, Object.keys(astCache).length);
-    const ast2After = astCache[formula2];
+    assert.strictEqual(2, astCache.size);
+    const ast2After = astCache.get(formula2);
 
     assert.strictEqual(
       ast2Before,
@@ -54,7 +54,7 @@ describe("CachedInterpreter", () => {
       () => interpreter.interpret("min(2, 3)"),
       D2FInterpreterError
     );
-    assert.strictEqual(1, Object.keys(astCache).length);
+    assert.strictEqual(1, astCache.size);
   });
 
   it("should not cache syntactically invalid formula", () => {
@@ -63,7 +63,7 @@ describe("CachedInterpreter", () => {
     const astCache = interpreter.astCache_;
 
     assert.throws(() => interpreter.interpret("max(2, )"), D2FSyntaxError);
-    assert.strictEqual(0, Object.keys(astCache).length);
+    assert.strictEqual(0, astCache.size);
   });
 
   it("should not treat Object.prototype builtins as formulae", () => {
@@ -78,6 +78,6 @@ describe("CachedInterpreter", () => {
     );
     assert.throws(() => interpreter.interpret("toString"), D2FInterpreterError);
     assert.throws(() => interpreter.interpret("valueOf"), D2FInterpreterError);
-    assert.strictEqual(3, Object.keys(astCache).length);
+    assert.strictEqual(3, astCache.size);
   });
 });

--- a/test/cached-interpreter.test.js
+++ b/test/cached-interpreter.test.js
@@ -1,0 +1,83 @@
+import { strict as assert } from "assert";
+
+import { CachedInterpreter } from "../src/cached-interpreter.js";
+import { D2FInterpreterError, D2FSyntaxError } from "../src/errors.js";
+
+describe("CachedInterpreter", () => {
+  it("should cache syntactically valid formulae", () => {
+    const interpreter = new CachedInterpreter();
+    // @ts-expect-error Accessing private property for test
+    const astCache = interpreter.astCache_;
+
+    assert.strictEqual(0, Object.keys(astCache).length);
+
+    const formula1 = "2 + 5";
+    const formula2 = "((12 + 34) / -5 < 100) ? 67 : 89";
+
+    interpreter.interpret(formula1);
+    assert.strictEqual(1, Object.keys(astCache).length);
+    assert.ok(Object.prototype.hasOwnProperty.call(astCache, formula1));
+    const ast1Before = astCache[formula1];
+
+    interpreter.interpret(formula1);
+    assert.strictEqual(1, Object.keys(astCache).length);
+    const ast1After = astCache[formula1];
+
+    assert.strictEqual(
+      ast1Before,
+      ast1After,
+      "AST must be the same object, not a new one"
+    );
+
+    interpreter.interpret(formula2);
+    assert.strictEqual(2, Object.keys(astCache).length);
+    assert.ok(Object.prototype.hasOwnProperty.call(astCache, formula2));
+    const ast2Before = astCache[formula2];
+
+    interpreter.interpret(formula2);
+    assert.strictEqual(2, Object.keys(astCache).length);
+    const ast2After = astCache[formula2];
+
+    assert.strictEqual(
+      ast2Before,
+      ast2After,
+      "AST must be the same object, not a new one"
+    );
+  });
+
+  it("should cache syntactically valid formula that throws interpreter error", () => {
+    const interpreter = new CachedInterpreter();
+    // @ts-expect-error Accessing private property for test
+    const astCache = interpreter.astCache_;
+
+    assert.throws(
+      () => interpreter.interpret("min(2, 3)"),
+      D2FInterpreterError
+    );
+    assert.strictEqual(1, Object.keys(astCache).length);
+  });
+
+  it("should not cache syntactically invalid formula", () => {
+    const interpreter = new CachedInterpreter();
+    // @ts-expect-error Accessing private property for test
+    const astCache = interpreter.astCache_;
+
+    assert.throws(() => interpreter.interpret("max(2, )"), D2FSyntaxError);
+    assert.strictEqual(0, Object.keys(astCache).length);
+  });
+
+  it("should not treat Object.prototype builtins as formulae", () => {
+    const interpreter = new CachedInterpreter();
+    // @ts-expect-error Accessing private property for test
+    const astCache = interpreter.astCache_;
+
+    // This should be treated as an unknown identifier
+    assert.throws(
+      () => interpreter.interpret("hasOwnProperty"),
+      D2FInterpreterError
+    );
+    assert.throws(() => interpreter.interpret("toString"), D2FInterpreterError);
+    assert.throws(() => interpreter.interpret("valueOf"), D2FInterpreterError);
+    assert.strictEqual(3, Object.keys(astCache).length);
+  });
+});


### PR DESCRIPTION
Previously, `CachedInterpreter` attempted to interpret `Object.prototype` builtin properties (e.g. `"toString"`) as cached ASTs when their names were given as formula strings. `CachedInterpreter` now uses a `Map` instead of a plain object, which solves the issue.

In code:

```js
const interpreter = new CachedInterpreter();

// Previously, this attempted to interpret Object.prototype.toString as an AST object (which failed with a TypeError).
// Now, it correctly throws a D2FInterpreterError("Unknown identifier: toString");
interpreter.interpret("toString");
```