### PR TITLE
ci: Run Prettier directly

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,7 @@ extends:
   - "eslint:recommended"
   # "plugin:import/errors" is unneeded because TypeScript already covers them
   - "plugin:import/warnings"
-  - "plugin:prettier/recommended"
+  - "prettier"
 ignorePatterns:
   - "dist/*"
 parserOptions:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Build artifacts
+/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,14 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.2.0] - 2020-08-14
+
 ### Fixed
+
 - `interpret()` now only uses identifiers, numeric functions, and reference
-  functions that are *directly-owned* properties of fields in the `environment`
+  functions that are _directly-owned_ properties of fields in the `environment`
   object. For example, the following no longer works:
 
   ```js
   class Parent {
-    myfunc(a, b) { /* ... */ }
+    myfunc(a, b) {
+      /* ... */
+    }
   }
   class Child extends Parent {}
 
@@ -25,39 +30,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This prevents inherited properties (such as those in `Object.prototype`) from
   accidentally leaking into the environment. (#3)
+
 - Fixed a bug that caused `CachedInterpreter.interpret()` to behave incorrectly
   when property names in `Object.prototype` were given as formulae. (#4)
 
 ### Security
+
 - Bumped development dependencies (Mocha, rollup-plugin-terser) to handle known
   vulnerability in serialize-javascript. This will not affect users of this
   library. (#5)
 
 ## [0.1.1] - 2020-07-21
+
 ### Fixed
+
 - Large numbers are properly coerced to 32-bit signed integers. (#1)
 - Calculation results and intermediate values are coerced to 32-bit signed
   integers. Values returned by identifier/numeric/reference functions are also
   coerced to 32-bit signed integers. (#2)
 
 ## [0.1.0] - 2020-07-19
+
 ### Added
+
 - Added `CachedInterpreter`, which caches the parsed AST tree for faster
   processing.
 - Provide single-file bundles in UMD and ESM formats.
-- Provide TypeScript type definitions (*.d.ts).
+- Provide TypeScript type definitions (\*.d.ts).
 
 ### Changed
+
 - Rewritten to use ECMAScript modules. d2calc can still be imported from Node.js
   in CommonJS mode.
 - Can now be installed on Node.js 10.x, though no guarantees are made on whether
   d2calc actually works on this version. **Use at your own risk.**
 
 ## [0.0.1] - 2020-07-17
+
 ### Added
+
 - Initial release
 
-[Unreleased]: https://github.com/pastelmind/d2calc/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/pastelmind/d2calc/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/pastelmind/d2calc/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/pastelmind/d2calc/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/pastelmind/d2calc/compare/v0.0.1...v0.1.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These text files contain many formulae that control how various skills operate.
 The syntax of the formulae is similar to the C language, with some differences.
 For convenience, we will refer to this language as **D2F**.
 
-[Diablo 2]: https://en.wikipedia.org/wiki/Diablo_II
+[diablo 2]: https://en.wikipedia.org/wiki/Diablo_II
 [tab-separated values]: https://en.wikipedia.org/wiki/Tab-separated_values
 
 ## Installing
@@ -26,32 +26,36 @@ npm install d2calc
 For use in web browsers, minified versions are also available in UMD and ESM
 formats. Check out the [Releases] page for details.
 
-[Releases]: https://github.com/pastelmind/d2calc/releases/
+[releases]: https://github.com/pastelmind/d2calc/releases/
 
 ## Usage
 
 d2calc exports a function named `interpret()`. It can be used like this:
 
 ```js
-const { interpret } = require('d2calc');
+const { interpret } = require("d2calc");
 const result = interpret("4 * (-2 + 25)"); // 92
 ```
 
 Or, with a custom environment object:
 
 ```js
-const { interpret } = require('d2calc');
+const { interpret } = require("d2calc");
 const environment = {
   identifiers: {
     lvl: 3,
-    ln12: () => { /* Do something here */ },
+    ln12: () => {
+      /* Do something here */
+    },
   },
   functions: {
     max: (a, b) => Math.max(a, b),
     min: (a, b) => Math.min(a, b),
   },
   referenceFunctions: {
-    stat: (ref, code) => { /* Do something here */ },
+    stat: (ref, code) => {
+      /* Do something here */
+    },
   },
 };
 
@@ -64,7 +68,7 @@ intermediate result of parsing the code. When the same code is interpreted
 later, it skips the parsing process, speeding up the result significantly.
 
 ```js
-const { CachedInterpreter } = require('d2calc');
+const { CachedInterpreter } = require("d2calc");
 const interpreter = new CachedInterpreter();
 
 const result = interpreter.interpret("-(125 + 12 * 3 - 2) / 3");
@@ -74,10 +78,10 @@ d2calc can also be imported inside ECMAScript modules:
 
 ```js
 // In Node.js >= 12.x, inside an ECMAScript module:
-import { interpret } from 'd2calc';
+import { interpret } from "d2calc";
 
 // In Node.js <= 10.x, inside an ECMAScript module:
-import d2calc from 'd2calc';
+import d2calc from "d2calc";
 const { interpret } = d2calc;
 ```
 
@@ -91,15 +95,15 @@ Interprets the `code` using the `environment` and returns the result.
 
 ##### `code`
 
-* Type: `string`
-* Required: Yes
+- Type: `string`
+- Required: Yes
 
 D2F code to interpret.
 
 ##### `environment`
 
-* Type: `object`
-* Required: No
+- Type: `object`
+- Required: No
 
 An object representing the environment to use while interpreting the code.
 
@@ -107,39 +111,39 @@ The object may contain the following fields:
 
 ##### `environment.identifiers`
 
-* Type:
+- Type:
   ```ts
   {
     [name: string]: number | () => number;
-  } 
+  }
   ```
-* Required: No
+- Required: No
 
 An object that maps each identifier name to its value. Each value can be either
 a `number`, or a function that takes no arguments and returns a `number`.
 
 ##### `environment.functions`
 
-* Type:
+- Type:
   ```ts
   {
     [name: string]: (a: number, b: number) => number;
-  } 
+  }
   ```
-* Required: No
+- Required: No
 
 An object that maps each numeric function name to a numeric function. Each
 numeric function must take two numbers as arguments and return a number.
 
 ##### `environment.referenceFunctions`
 
-* Type:
+- Type:
   ```ts
   {
     [name: string]: (ref: string | number, code: string) => number;
-  } 
+  }
   ```
-* Required: No
+- Required: No
 
 An object that maps each function name to a single-qualifier reference function.
 Each reference function must take two arguments: a reference (`string` or
@@ -147,13 +151,13 @@ Each reference function must take two arguments: a reference (`string` or
 
 ##### `environment.referenceFunctions2Q`
 
-* Type:
+- Type:
   ```ts
   {
     [name: string]: (ref: string | number, code1: string, code2: string) => number;
-  } 
+  }
   ```
-* Required: No
+- Required: No
 
 An object that maps each function name to a double-qualifier reference function.
 Each reference function must take three arguments: a reference (`string` or
@@ -180,24 +184,24 @@ d2calc throws a family of exceptions, depending on the nature of the error. Each
 exception class can be imported like this:
 
 ```js
-const { D2FSyntaxError, D2FInterpreterError } = require('d2calc');
+const { D2FSyntaxError, D2FInterpreterError } = require("d2calc");
 ```
 
 The exception hierarchy:
 
-* `D2CalcError`: Base class for all exceptions thrown by this package.
-    * `D2FError`: Base class for all exceptions caused by a D2F code error.
-        * `D2FInterpreterError`: Thrown if the code contains no syntax errors, but cannot be interpreted because it uses an identifier or function in an incorrect way.
-        * `D2FSyntaxError`: Thrown if the code contains a syntax error.
-    * `D2CalcInternalError`: Used internally for catching bugs. This exception is not intended to be catched by users.
+- `D2CalcError`: Base class for all exceptions thrown by this package.
+  - `D2FError`: Base class for all exceptions caused by a D2F code error.
+    - `D2FInterpreterError`: Thrown if the code contains no syntax errors, but cannot be interpreted because it uses an identifier or function in an incorrect way.
+    - `D2FSyntaxError`: Thrown if the code contains a syntax error.
+  - `D2CalcInternalError`: Used internally for catching bugs. This exception is not intended to be catched by users.
 
 ## D2F Language Reference
 
 This section is based on the [Formulae Guide] from the [Phrozen Keep], as well
 as [my own research](https://github.com/pastelmind/d2test/tree/test/operators).
 
-[Formulae Guide]: https://d2mods.info/forum/kb/viewarticle?a=371
-[Phrozen Keep]: https://d2mods.info/
+[formulae guide]: https://d2mods.info/forum/kb/viewarticle?a=371
+[phrozen keep]: https://d2mods.info/
 
 The mini-language used by Diablo 2 (henceforth "D2F") supports only one
 datatype: the signed 32-bit integer (i.e. DWORD).
@@ -223,20 +227,20 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" |
 digit  = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-An *identifier* is the name of a built-in function or a qualifier.
+An _identifier_ is the name of a built-in function or a qualifier.
 
-A *reference* is the name of a skill, missile, or stat in the text files,
+A _reference_ is the name of a skill, missile, or stat in the text files,
 surrounded by single quotes (`''`).
 
-A *dot code* is a single dot (`.`) immediately followed by a qualifier name.
+A _dot code_ is a single dot (`.`) immediately followed by a qualifier name.
 
-A *qualifier* is an identifier associated with a skill, missile, or stat.
+A _qualifier_ is an identifier associated with a skill, missile, or stat.
 Each qualifier represents a value in a text file, an in-game property, or a
 computed value.
 
-* Qualifiers for skills are defined in `SkillCalc.txt`.
-* Qualifiers for missiles are defined in `MissCalc.txt`.
-* Stats have the following built-in qualifiers: `base`, `accr`, `mod`
+- Qualifiers for skills are defined in `SkillCalc.txt`.
+- Qualifiers for missiles are defined in `MissCalc.txt`.
+- Stats have the following built-in qualifiers: `base`, `accr`, `mod`
 
 ### Expressions
 

--- a/jsconfig.build.json
+++ b/jsconfig.build.json
@@ -8,10 +8,8 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "noEmit": false,
-    "outDir": "dist/",
+    "outDir": "dist/"
   },
   "extends": "./jsconfig.json",
-  "files": [
-    "index.js",
-  ],
+  "files": ["index.js"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,9 +8,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "es2015",
+    "target": "es2015"
   },
-  "exclude": [
-    "dist/",
-  ],
+  "exclude": ["dist/"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -689,15 +689,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -806,12 +797,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1722,15 +1707,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "rollup --config && tsc -p jsconfig.build.json",
     "clean": "rm -rf ./dist/*",
-    "lint": "eslint . && tsc -p jsconfig.json",
+    "lint": "eslint . && tsc -p jsconfig.json && prettier --check .",
     "prepare": "npm run build",
     "test": "mocha --experimental-modules"
   },
@@ -43,7 +43,6 @@
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prettier": "^3.4.0",
     "mocha": "^8.3.2",
     "prettier": "^2.2.1",
     "rollup": "^2.45.2",


### PR DESCRIPTION
Prettier [no longer recommends](https://prettier.io/docs/en/integrating-with-linters.html#notes) using [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier). Instead, it encourages running it directly as a separate process. I'm happy to drop one dependency without any major hassle.