### PR TITLE
refactor: use TS 4.5 const assertions

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -12,7 +12,6 @@ import {
   ReferenceToken,
   tokenize,
 } from "./lexer.js";
-import { _c } from "./types.js";
 
 /**
  * @typedef {import("./int32.js").Int32} Int32
@@ -417,7 +416,7 @@ export class AstBinaryOp {
    * @param {AstExpression} right Right side expression
    */
   constructor(operator, left, right) {
-    this.type = _c("AstBinaryOp");
+    this.type = /** @type {const} */ ("AstBinaryOp");
     this.operator = operator;
     this.left = left;
     this.right = right;
@@ -430,7 +429,7 @@ export class AstUnaryOp {
    * @param {AstExpression} expression Expression to apply the operator
    */
   constructor(operator, expression) {
-    this.type = _c("AstUnaryOp");
+    this.type = /** @type {const} */ ("AstUnaryOp");
     this.operator = operator;
     this.expression = expression;
   }
@@ -443,7 +442,7 @@ export class AstConditional {
    * @param {AstExpression} falseExpression Expression to evaluate if condition is false (zero)
    */
   constructor(condition, trueExpression, falseExpression) {
-    this.type = _c("AstConditional");
+    this.type = /** @type {const} */ ("AstConditional");
     this.condition = condition;
     this.trueExpression = trueExpression;
     this.falseExpression = falseExpression;
@@ -463,7 +462,7 @@ export class AstNumber extends AstIntegralExpression {
    */
   constructor(value) {
     super();
-    this.type = _c("AstNumber");
+    this.type = /** @type {const} */ ("AstNumber");
     this.value = value;
   }
 }
@@ -474,7 +473,7 @@ export class AstIdentifier extends AstIntegralExpression {
    */
   constructor(name) {
     super();
-    this.type = _c("AstIdentifier");
+    this.type = /** @type {const} */ ("AstIdentifier");
     this.name = name;
   }
 }
@@ -487,7 +486,7 @@ export class AstFunctionCall extends AstIntegralExpression {
    */
   constructor(functionName, arg1, arg2) {
     super();
-    this.type = _c("AstFunctionCall");
+    this.type = /** @type {const} */ ("AstFunctionCall");
     this.functionName = functionName;
     this.arg1 = arg1;
     this.arg2 = arg2;
@@ -503,7 +502,7 @@ export class AstRefFunctionCall extends AstIntegralExpression {
    */
   constructor(functionName, reference, code1, code2) {
     super();
-    this.type = _c("AstRefFunctionCall");
+    this.type = /** @type {const} */ ("AstRefFunctionCall");
     this.functionName = functionName;
     this.reference = reference;
     this.code1 = code1;

--- a/src/types.js
+++ b/src/types.js
@@ -12,12 +12,5 @@
  * @typedef {T & Branded<B>} Nominal
  */
 
-/**
- * Helper function for creating number and string literal types.
- * @template {number | string} T
- * @param {T} value
- * @return {T}
- */
-export function _c(value) {
-  return value;
-}
+// Dummy export statement, needed to make TypeScript treat this file as a module
+export {};


### PR DESCRIPTION
TypeScript 4.5 supports const assertions in JSDoc comments (see [related issue](https://github.com/microsoft/TypeScript/issues/30445)). This allows us to remove the `_c()` function, previously used as a workaround. This should make the lexer very slightly faster and won't affect any semantics.